### PR TITLE
feat(log): Implement LogManager for handling log records

### DIFF
--- a/src/file/block_id.rs
+++ b/src/file/block_id.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 /// Represents a unique identifier for a block within a file.
 ///
 /// A `BlockId` is made up of a file name (`String`) and a block number (`u32`).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BlockId {
     file_name: String,
     block_number: u32,

--- a/src/log/err.rs
+++ b/src/log/err.rs
@@ -1,0 +1,46 @@
+use std::fmt;
+
+/// Represents errors that can occur within the logging system.
+///
+/// This enum contains variants for file manager errors, block-related errors,
+/// page-related errors, IO errors, and mutex lock errors.
+#[derive(Debug)]
+pub enum LogError {
+    /// Errors specific to file manager operations.
+    FileManagerError(String),
+
+    /// Errors specific to block operations.
+    BlockError(String),
+
+    /// Errors specific to page operations.
+    PageError(String),
+
+    /// Wrapper around standard IO errors.
+    IOError(String),
+
+    /// An error indicating that locking a mutex failed.
+    MutexLockError,
+}
+
+impl fmt::Display for LogError {
+    /// Formats the `LogError` variants as a human-readable string.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LogError::FileManagerError(msg) => write!(f, "FileManagerError: {}", msg),
+            LogError::BlockError(msg) => write!(f, "BlockError: {}", msg),
+            LogError::PageError(msg) => write!(f, "PageError: {}", msg),
+            LogError::IOError(msg) => write!(f, "IOError: {}", msg),
+            LogError::MutexLockError => write!(f, "MutexLockError: Failed to acquire lock"),
+        }
+    }
+}
+
+impl std::error::Error for LogError {
+    /// Provides a source error, if any, for the `LogError` variants.
+    ///
+    /// Currently, this function returns `None` as the `LogError` variants
+    /// do not wrap other errors.
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}

--- a/src/log/log_iterator.rs
+++ b/src/log/log_iterator.rs
@@ -1,0 +1,110 @@
+use crate::file::block_id::BlockId;
+use crate::file::file_manager::FileManager;
+use crate::file::page::Page;
+use crate::log::err::LogError;
+use std::iter::Iterator;
+
+/// `LogIterator` is an iterator over the log records in a log file.
+///
+/// It allows for sequential reading of log records stored in blocks.
+/// The iterator starts from a given block and reads records until no more are available.
+pub struct LogIterator<'a> {
+    file_manager: &'a FileManager,
+    block: BlockId,
+    page: Page,
+    current_position: usize,
+    boundary: usize,
+}
+
+impl<'a> LogIterator<'a> {
+    /// Creates a new `LogIterator` starting from a given block.
+    ///
+    /// # Arguments
+    ///
+    /// * `file_manager`: Reference to the `FileManager` for file operations.
+    /// * `block`: The `BlockId` where the iterator starts.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `LogError` if reading the block or page fails.
+    pub fn new(file_manager: &'a FileManager, block: BlockId) -> Result<Self, LogError> {
+        let mut page = Page::new_from_blocksize(file_manager.get_block_size());
+        let mut log_iterator = LogIterator {
+            file_manager,
+            block: block.clone(),
+            page,
+            current_position: 0,
+            boundary: 0,
+        };
+        log_iterator
+            .move_to_block(block)
+            .map_err(|e| LogError::BlockError(e.to_string()))?;
+        Ok(log_iterator)
+    }
+
+    /// Checks if there are more records to read.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if more records are available, otherwise `false`.
+    pub fn has_next(&self) -> bool {
+        self.current_position < self.file_manager.get_block_size()
+            || 0 < self.block.get_block_number()
+    }
+
+    /// Moves the iterator to a new block.
+    ///
+    /// # Arguments
+    ///
+    /// * `block`: The `BlockId` to move to.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `LogError` if reading the block or page fails.
+    fn move_to_block(&mut self, block: BlockId) -> Result<(), LogError> {
+        self.file_manager
+            .read(&block, &mut self.page)
+            .map_err(|e| LogError::BlockError(e.to_string()))?;
+        self.boundary = self
+            .page
+            .get_int(0)
+            .map_err(|e| LogError::PageError(e.to_string()))? as usize;
+        self.current_position = self.boundary;
+        Ok(())
+    }
+}
+
+impl<'a> Iterator for LogIterator<'a> {
+    type Item = Result<Vec<u8>, LogError>;
+
+    /// Fetches the next log record.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(Ok(record))` if a record is successfully read,
+    /// `Some(Err(e))` if an error occurs, and `None` if no more records are available.
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.has_next() {
+            return None;
+        }
+
+        if self.current_position == self.file_manager.get_block_size() {
+            self.block = BlockId::new(
+                self.block.get_file_name().to_string(),
+                self.block.get_block_number().saturating_sub(1),
+            );
+            if let Err(e) = self.move_to_block(self.block.clone()) {
+                return Some(Err(e));
+            }
+        }
+
+        let record_result = self.page.get_bytes(self.current_position);
+        match record_result {
+            Ok(record) => {
+                self.current_position += std::mem::size_of::<i32>() + record.len();
+                Some(Ok(record))
+            }
+            Err(e) => Some(Err(LogError::PageError(e.to_string()))),
+        }
+    }
+}

--- a/src/log/log_manager.rs
+++ b/src/log/log_manager.rs
@@ -1,0 +1,192 @@
+use crate::file::block_id::BlockId;
+use crate::file::file_manager::FileManager;
+use crate::file::page::Page;
+use crate::log::err::LogError;
+use crate::log::log_iterator::LogIterator;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+/// `LogManager` manages the writing and reading of log records.
+///
+/// It keeps track of the current log block, the latest log sequence number (LSN),
+/// and the last saved LSN.
+pub struct LogManager {
+    file_manager: Arc<FileManager>,
+    log_file: String,
+    log_page: Page,
+    current_block: BlockId,
+    latest_lsn: Mutex<i32>,
+    last_saved_lsn: Mutex<i32>,
+}
+
+impl LogManager {
+    /// Creates a new `LogManager`.
+    ///
+    /// # Arguments
+    ///
+    /// * `file_manager`: An `Arc` wrapped `FileManager` for file operations.
+    /// * `log_file`: The name of the log file.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `LogError` if initialization fails.
+    pub fn new(file_manager: Arc<FileManager>, log_file: String) -> Result<Self, LogError> {
+        let mut log_page = Page::new_from_blocksize(file_manager.get_block_size());
+        let logsize = file_manager
+            .length(&log_file)
+            .map_err(|e| LogError::FileManagerError(e.to_string()))?;
+
+        let current_block = if logsize == 0 {
+            Self::append_new_block(&file_manager, &log_file, &mut log_page)
+                .map_err(|e| LogError::FileManagerError(e.to_string()))?
+        } else {
+            let block = BlockId::new(log_file.clone(), logsize - 1);
+            file_manager
+                .read(&block, &mut log_page)
+                .map_err(|e| LogError::FileManagerError(e.to_string()))?;
+            block
+        };
+
+        Ok(LogManager {
+            file_manager,
+            log_file,
+            log_page,
+            current_block,
+            latest_lsn: Mutex::new(0),
+            last_saved_lsn: Mutex::new(0),
+        })
+    }
+
+    /// Flushes log records up to a given LSN.
+    ///
+    /// # Arguments
+    ///
+    /// * `lsn`: The log sequence number up to which records should be flushed.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `LogError` if flushing fails.
+    pub fn flush_by_lsn(&mut self, lsn: i32) -> Result<(), LogError> {
+        let last_saved_lsn = *self
+            .last_saved_lsn
+            .lock()
+            .map_err(|_| LogError::MutexLockError)?;
+        if lsn >= last_saved_lsn {
+            self.flush()?;
+        }
+        Ok(())
+    }
+
+    /// Returns a `LogIterator` for reading log records.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `LogError` if iterator creation fails.
+    pub fn iterator(&mut self) -> Result<LogIterator, LogError> {
+        self.flush()?;
+        Ok(LogIterator::new(
+            &self.file_manager,
+            self.current_block.clone(),
+        )?)
+    }
+
+    /// Appends a log record to the log file.
+    ///
+    /// # Arguments
+    ///
+    /// * `log_record`: The log record to append.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `LogError` if appending fails.
+    ///
+    /// # Returns
+    ///
+    /// Returns the LSN of the appended log record.
+    pub fn append(&mut self, log_record: &[u8]) -> Result<i32, LogError> {
+        let mut boundary = self
+            .log_page
+            .get_int(0)
+            .map_err(|e| LogError::PageError(e.to_string()))? as usize;
+        let record_size = log_record.len();
+        let bytes_needed = record_size + std::mem::size_of::<i32>();
+
+        if boundary.checked_sub(bytes_needed).unwrap_or(0) < std::mem::size_of::<i32>() {
+            self.flush()?;
+            self.current_block =
+                Self::append_new_block(&self.file_manager, &self.log_file, &mut self.log_page)?;
+            boundary = self
+                .log_page
+                .get_int(0)
+                .map_err(|e| LogError::PageError(e.to_string()))? as usize;
+        }
+
+        let record_position = boundary - bytes_needed;
+        self.log_page
+            .set_bytes(record_position, log_record)
+            .map_err(|e| LogError::PageError(e.to_string()))?;
+
+        self.log_page
+            .set_int(0, record_position as i32)
+            .map_err(|e| LogError::PageError(e.to_string()))?;
+        let mut latest_lsn = self
+            .latest_lsn
+            .lock()
+            .map_err(|_| LogError::MutexLockError)?;
+        *latest_lsn += 1;
+        Ok(*latest_lsn)
+    }
+
+    /// Appends a new block to the log file.
+    ///
+    /// # Arguments
+    ///
+    /// * `file_manager`: Reference to the `FileManager` for file operations.
+    /// * `log_file`: The name of the log file.
+    /// * `log_page`: The log page to write.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `LogError` if appending a new block fails.
+    ///
+    /// # Returns
+    ///
+    /// Returns the `BlockId` of the new block.
+    fn append_new_block(
+        file_manager: &FileManager,
+        log_file: &String,
+        log_page: &mut Page,
+    ) -> Result<BlockId, LogError> {
+        let block = file_manager
+            .append(log_file)
+            .map_err(|e| LogError::FileManagerError(e.to_string()))?;
+        log_page
+            .set_int(0, file_manager.get_block_size() as i32)
+            .map_err(|e| LogError::PageError(e.to_string()))?;
+        file_manager
+            .write(&block, log_page)
+            .map_err(|e| LogError::FileManagerError(e.to_string()))?;
+        Ok(block)
+    }
+
+    /// Flushes the current log page to disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `LogError` if flushing fails.
+    fn flush(&mut self) -> Result<(), LogError> {
+        self.file_manager
+            .write(&self.current_block, &mut self.log_page)
+            .map_err(|e| LogError::FileManagerError(e.to_string()))?;
+        let mut last_saved_lsn = self
+            .last_saved_lsn
+            .lock()
+            .map_err(|_| LogError::MutexLockError)?;
+        let latest_lsn = *self
+            .latest_lsn
+            .lock()
+            .map_err(|_| LogError::MutexLockError)?;
+        *last_saved_lsn = latest_lsn;
+        Ok(())
+    }
+}

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -1,0 +1,3 @@
+pub mod err;
+pub mod log_iterator;
+pub mod log_manager;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,8 @@
 mod file;
+mod log;
 mod server;
 
-fn main() {
-    println!("Hello, world!");
-}
+fn main() {}
 
 #[cfg(test)]
-mod tests {
-    mod file_test;
-}
+mod tests;

--- a/src/server/oxide_db.rs
+++ b/src/server/oxide_db.rs
@@ -1,22 +1,33 @@
 use crate::file::file_manager::FileManager;
+use crate::log::log_manager::LogManager;
 use std::path::PathBuf;
+use std::sync::Arc;
+
+const LOG_FILE: &str = "oxidedb.log";
 
 pub struct OxideDB {
     block_size: usize,
-    file_manager: FileManager,
+    file_manager: Arc<FileManager>,
+    log_manager: LogManager,
 }
 
 impl OxideDB {
     pub fn new_for_debug(db_directory: PathBuf, block_size: usize) -> OxideDB {
-        let file_manager = FileManager::new(db_directory, block_size).unwrap();
+        let file_manager = Arc::new(FileManager::new(db_directory, block_size).unwrap());
+        let log_manager = LogManager::new(Arc::clone(&file_manager), LOG_FILE.to_string()).unwrap();
+
         OxideDB {
-            block_size,
+            block_size: file_manager.get_block_size(),
             file_manager,
+            log_manager,
         }
     }
 
-    // Accessor methods for debugging
     pub fn get_file_manager(&self) -> &FileManager {
-        return &self.file_manager;
+        &self.file_manager
+    }
+
+    pub fn get_log_manager(&mut self) -> &mut LogManager {
+        &mut self.log_manager
     }
 }

--- a/src/tests/log_test.rs
+++ b/src/tests/log_test.rs
@@ -1,0 +1,152 @@
+use crate::file::page::Page;
+use crate::log::err::LogError;
+use crate::log::log_manager::LogManager;
+use crate::server::oxide_db::OxideDB;
+use std::path::PathBuf;
+
+/// Tests log management operations in `LogManager`.
+///
+/// This test does the following:
+/// - Creates a new OxideDB instance for debugging with a given path and block size.
+/// - Creates log records and appends them to the log file.
+/// - Flushes the log records up to a certain LSN.
+/// - Reads back the log records and checks if they match the expected records.
+#[test]
+fn log_test() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize a new OxideDB instance for debugging
+    let mut db = OxideDB::new_for_debug(PathBuf::from("logtest"), 400);
+
+    // Acquire a LogManager to perform log operations
+    let mut log_manager = db.get_log_manager();
+
+    // Print the initial empty log file
+    print_log_records(&mut log_manager, "The initial empty log file:", &[])?;
+
+    // Create and append log records from 1 to 35
+    create_records(&mut log_manager, 1, 35).map_err(|e| LogError::IOError(e.to_string()))?;
+
+    // Define expected records after the first batch and print them
+    let expected_after_first_batch = (1..=35)
+        .rev()
+        .map(|i| (format!("record{}", i), i + 100))
+        .collect::<Vec<_>>();
+    print_log_records(
+        &mut log_manager,
+        "The log file now has these records:",
+        &expected_after_first_batch,
+    )?;
+
+    // Create and append log records from 36 to 70
+    create_records(&mut log_manager, 36, 70)?;
+
+    // Flush log records up to LSN 65
+    log_manager.flush_by_lsn(65)?;
+
+    // Define expected records after the second batch and print them
+    let expected_after_second_batch = (1..=70)
+        .rev()
+        .map(|i| (format!("record{}", i), i + 100))
+        .collect::<Vec<_>>();
+    print_log_records(
+        &mut log_manager,
+        "The log file now has these records:",
+        &expected_after_second_batch,
+    )?;
+    Ok(())
+}
+
+/// Prints log records and checks if they match the expected records.
+///
+/// # Arguments
+///
+/// * `log_manager`: The `LogManager` to use for reading log records.
+/// * `msg`: The message to print before printing log records.
+/// * `expected_records`: The expected log records.
+///
+/// # Errors
+///
+/// Returns a `LogError` if reading or matching fails.
+fn print_log_records(
+    log_manager: &mut LogManager,
+    msg: &str,
+    expected_records: &[(String, i32)],
+) -> Result<(), LogError> {
+    println!("{}", msg);
+    let mut idx = 0;
+    let iterator = log_manager.iterator()?;
+    for record in iterator {
+        match record {
+            Ok(bytes) => {
+                let mut page = Page::new_from_bytes(bytes);
+                let string = page
+                    .get_string(0)
+                    .map_err(|e| LogError::PageError(e.to_string()))?;
+                let number_position = Page::max_length(string.len());
+                let value = page
+                    .get_int(number_position)
+                    .map_err(|e| LogError::PageError(e.to_string()))?;
+
+                assert_eq!(
+                    (string, value),
+                    expected_records[idx],
+                    "Record does not match expected value"
+                );
+                idx += 1;
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        }
+    }
+    assert_eq!(
+        idx,
+        expected_records.len(),
+        "Number of records does not match expected count"
+    );
+    Ok(())
+}
+
+/// Creates and appends log records to the log file using `LogManager`.
+///
+/// # Arguments
+///
+/// * `log_manager`: The `LogManager` to use for appending log records.
+/// * `start`: The starting integer value for creating log records.
+/// * `end`: The ending integer value for creating log records.
+///
+/// # Errors
+///
+/// Returns a `LogError` if appending a log record fails.
+fn create_records(log_manager: &mut LogManager, start: i32, end: i32) -> Result<(), LogError> {
+    println!("Creating records: ");
+    for i in start..=end {
+        let record = create_log_record(format!("record{}", i), i + 100)?;
+        let lsn = log_manager.append(&record)?;
+        println!("{} ", lsn);
+    }
+    println!();
+    Ok(())
+}
+
+/// Creates a log record consisting of a string and an integer.
+///
+/// # Arguments
+///
+/// * `s`: The string to include in the log record.
+/// * `n`: The integer to include in the log record.
+///
+/// # Errors
+///
+/// Returns a `LogError` if setting the string or integer in the page fails.
+fn create_log_record(s: String, n: i32) -> Result<Vec<u8>, LogError> {
+    let string_position = 0;
+    let number_position = string_position + Page::max_length(s.len());
+    let blocksize = number_position + std::mem::size_of::<i32>();
+    let mut page = Page::new_from_blocksize(blocksize);
+    page.set_string(string_position, &s)
+        .map_err(|e| LogError::PageError(e.to_string()))?;
+    page.set_int(number_position, n)
+        .map_err(|e| LogError::PageError(e.to_string()))?;
+    page.read_bytes(0, blocksize)
+        .map_err(|e| LogError::PageError(e.to_string()))
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,2 @@
+pub mod file_test;
+pub mod log_test;


### PR DESCRIPTION
- Implement LogManager struct with core functionalities
  - Add methods for appending log records to a file
  - Implement flush_by_lsn to flush logs up to a given Log Sequence Number (LSN)
  - Add iterator method for reading log records

- Introduce LogIterator for iterating through log records
  - Implement Iterator trait for LogIterator
  - Add methods for block navigation and record retrieval

- Add Mutex for thread-safe LSN tracking
  - Implement latest_lsn and last_saved_lsn as Mutex<i32> for concurrency control

- Implement utility functions
  - Add create_log_record for generating log records
  - Implement create_records for batch record creation

- Add unit tests
  - Implement log_test for testing LogManager functionalities
  - Add utility functions for test setup and validation

- Document the code
  - Add Rustdoc comments for LogManager, LogIterator, and associated functions
  - Provide explanations for arguments and errors in the documentation