### PR TITLE
feat(buffer): Implement BufferManager for managing buffer pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "rust-dbms"
+name = "oxide_db"
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust-dbms"
+name = "oxide_db"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -1,0 +1,131 @@
+use crate::buffer::err::BufferError;
+use crate::file::block_id::BlockId;
+use crate::file::err::FileManagerError;
+use crate::file::file_manager::FileManager;
+use crate::file::page::Page;
+use crate::log::log_manager::LogManager;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+/// `Buffer` wraps a page and stores information about its status,
+/// such as the associated disk block, the number of times the buffer has been pinned,
+/// whether its contents have been modified, and if so, the id and lsn of the modifying transaction.
+pub struct Buffer {
+    file_manager: Arc<Mutex<FileManager>>,
+    log_manager: Arc<Mutex<LogManager>>,
+    contents: Page,
+    block: Option<BlockId>,
+    pins: i32,
+    transaction_number: i32,
+    lsn: i32,
+}
+
+impl Buffer {
+    /// Creates a new `Buffer` with initial settings.
+    ///
+    /// This function initializes a new buffer with the given FileManager and LogManager.
+    /// It also sets the initial block size based on the FileManager's block size.
+    ///
+    /// # Arguments
+    ///
+    /// * `file_manager`: An `Arc` wrapped `FileManager` for file operations.
+    /// * `log_manager`: An `Arc` wrapped `LogManager` for log operations.
+    pub fn new(
+        file_manager: Arc<Mutex<FileManager>>,
+        log_manager: Arc<Mutex<LogManager>>,
+    ) -> Result<Self, BufferError> {
+        let block_size = file_manager
+            .lock()
+            .map_err(|_| BufferError::MutexLockError)?
+            .get_block_size();
+        let contents = Page::new_from_blocksize(block_size);
+        Ok(Buffer {
+            file_manager,
+            log_manager,
+            contents,
+            block: None,
+            pins: 0,
+            transaction_number: -1,
+            lsn: -1,
+        })
+    }
+
+    /// Returns the contents of the buffer.
+    pub fn get_contents(&mut self) -> &mut Page {
+        &mut self.contents
+    }
+
+    /// Returns a reference to the disk block allocated to the buffer.
+    pub fn get_block(&self) -> Option<&BlockId> {
+        self.block.as_ref()
+    }
+
+    /// Sets the buffer as modified by a transaction.
+    pub fn set_modified(&mut self, transaction_number: i32, lsn: i32) {
+        self.transaction_number = transaction_number;
+        if lsn >= 0 {
+            self.lsn = lsn;
+        }
+    }
+
+    /// Returns true if the buffer is currently pinned.
+    pub fn is_pinned(&self) -> bool {
+        self.pins > 0
+    }
+
+    /// Returns the ID of the modifying transaction.
+    pub fn modifying_transaction(&self) -> i32 {
+        self.transaction_number
+    }
+
+    /// Writes the buffer to its disk block if it is dirty.
+    /// This function locks the LogManager and FileManager to ensure thread safety.
+    pub fn assign_to_block(&mut self, b: BlockId) -> Result<(), BufferError> {
+        self.flush()?;
+        self.block = Some(b.clone());
+        self.file_manager
+            .lock()
+            .map_err(|_| BufferError::MutexLockError)?
+            .read(&b, &mut self.contents)
+            .map_err(BufferError::from)?;
+
+        self.pins = 0;
+        Ok(())
+    }
+
+    /// Writes the buffer to its disk block if it is dirty.
+    pub fn flush(&mut self) -> Result<(), BufferError> {
+        if self.transaction_number >= 0 {
+            {
+                let mut log_manager = self
+                    .log_manager
+                    .lock()
+                    .map_err(|_| BufferError::MutexLockError)?;
+                log_manager
+                    .flush_by_lsn(self.lsn)
+                    .map_err(BufferError::from)?;
+            }
+            if let Some(ref block) = self.block {
+                let mut file_manager = self
+                    .file_manager
+                    .lock()
+                    .map_err(|_| BufferError::MutexLockError)?;
+                file_manager
+                    .write(block, &mut self.contents)
+                    .map_err(BufferError::from)?;
+            }
+            self.transaction_number = -1;
+        }
+        Ok(())
+    }
+
+    /// Increases the buffer's pin count.
+    pub fn pin(&mut self) {
+        self.pins += 1;
+    }
+
+    /// Decreases the buffer's pin count.
+    pub fn unpin(&mut self) {
+        self.pins -= 1;
+    }
+}

--- a/src/buffer/buffer_manager.rs
+++ b/src/buffer/buffer_manager.rs
@@ -1,0 +1,230 @@
+use crate::buffer::buffer::Buffer;
+use crate::buffer::err::BufferAbortException;
+use crate::buffer::err::BufferError;
+use crate::file::block_id::BlockId;
+use crate::file::file_manager::FileManager;
+use crate::log::log_manager::LogManager;
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+/// Manages a pool of buffers.
+///
+/// `BufferManager` is responsible for allocating buffers to disk blocks,
+/// tracking the availability of buffers, and ensuring safe concurrent access.
+pub struct BufferManager {
+    buffer_pool: Vec<Mutex<Buffer>>,
+    number_available: Mutex<usize>,
+    max_time: u64,
+    condvar: Condvar,
+}
+
+impl BufferManager {
+    /// Creates a new `BufferManager` with the given FileManager and LogManager.
+    ///
+    /// # Arguments
+    ///
+    /// * `file_manager`: An `Arc` wrapped `FileManager` for file operations.
+    /// * `log_manager`: An `Arc` wrapped `LogManager` for log operations.
+    /// * `number_buffers`: The number of buffers to be managed.
+    pub fn new(
+        file_manager: Arc<Mutex<FileManager>>,
+        log_manager: Arc<Mutex<LogManager>>,
+        number_buffers: usize,
+    ) -> Result<Self, BufferError> {
+        let buffer_pool: Result<Vec<Mutex<Buffer>>, BufferError> = (0..number_buffers)
+            .map(|_| {
+                let buffer = Buffer::new(file_manager.clone(), log_manager.clone())?;
+                Ok(Mutex::new(buffer))
+            })
+            .collect();
+
+        let buffer_pool = buffer_pool?;
+
+        Ok(Self {
+            buffer_pool,
+            number_available: Mutex::new(number_buffers),
+            max_time: 10000,
+            condvar: Condvar::new(),
+        })
+    }
+
+    /// Returns the number of available buffers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the mutex lock is poisoned.
+    pub fn get_number_available(&self) -> Result<MutexGuard<usize>, BufferError> {
+        let number_available = self
+            .number_available
+            .lock()
+            .map_err(|_| BufferError::MutexLockError)?;
+        Ok(number_available)
+    }
+
+    /// Flushes all dirty buffers associated with a transaction to disk.
+    ///
+    /// # Arguments
+    ///
+    /// * `txnum`: The transaction number.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the mutex lock is poisoned or if flushing fails.
+    pub fn flush_all(&self, txnum: i32) -> Result<(), BufferError> {
+        for buffer_mutex in &self.buffer_pool {
+            let mut buffer = buffer_mutex
+                .lock()
+                .map_err(|_| BufferError::MutexLockError)?;
+            if buffer.modifying_transaction() == txnum {
+                buffer.flush()?; // Assuming `flush` returns a `Result`
+            }
+        }
+        Ok(())
+    }
+
+    /// Unpins a buffer and possibly makes it available for other transactions.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer`: A mutex guard that provides access to a buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the mutex lock is poisoned.
+    pub fn unpin(&self, buffer: MutexGuard<Buffer>) -> Result<(), BufferError> {
+        let mut buffer = buffer;
+        buffer.unpin();
+        let mut number_available = self.get_number_available()?;
+        if !buffer.is_pinned() {
+            *number_available += 1;
+            self.condvar.notify_all();
+        }
+        Ok(())
+    }
+
+    /// Pins a buffer to a disk block and locks it for a transaction.
+    ///
+    /// # Arguments
+    ///
+    /// * `block`: The disk block to be pinned.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no buffer is available or if the mutex lock is poisoned.
+    pub fn pin(&self, block: BlockId) -> Result<MutexGuard<Buffer>, BufferError> {
+        let start_time = Instant::now();
+        let timeout = Duration::from_millis(self.max_time);
+        loop {
+            if let Some(buffer) = self.try_to_pin(&block)? {
+                return Ok(buffer);
+            }
+            if self.waiting_too_long(start_time) {
+                return Err(BufferError::from(BufferAbortException));
+            }
+            let number_available = self.get_number_available()?;
+
+            let (_lock, timeout_result) = self
+                .condvar
+                .wait_timeout(number_available, timeout)
+                .map_err(|_| BufferError::MutexLockError)?;
+
+            // Handle timeout_result as needed. It is a bool that's true if a timeout occurred.
+            if timeout_result.timed_out() {
+                return Err(BufferError::from(BufferAbortException));
+            }
+        }
+    }
+
+    /// Tries to pin a buffer to the provided block.
+    ///
+    /// # Arguments
+    ///
+    /// * `block`: The `BlockId` for which a buffer is required.
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Option` containing a `MutexGuard` for a `Buffer` if one is available.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the mutex lock is poisoned.
+    fn try_to_pin(&self, block: &BlockId) -> Result<Option<MutexGuard<Buffer>>, BufferError> {
+        let mut number_available = self.get_number_available()?;
+        if let Some(mut buffer) = self.find_existing_buffer(block)? {
+            if !buffer.is_pinned() {
+                *number_available -= 1;
+            }
+            buffer.pin();
+            return Ok(Some(buffer));
+        }
+        if let Some(mut buffer) = self.choose_unpinned_buffer()? {
+            buffer.assign_to_block(block.clone());
+            *number_available -= 1;
+            buffer.pin();
+            return Ok(Some(buffer));
+        }
+        Ok(None)
+    }
+
+    /// Finds an existing buffer for the given block.
+    ///
+    /// # Arguments
+    ///
+    /// * `block`: The `BlockId` to find the buffer for.
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Option` containing a `MutexGuard` for a `Buffer` if one exists for the block.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the mutex lock is poisoned.
+    pub fn find_existing_buffer(
+        &self,
+        block: &BlockId,
+    ) -> Result<Option<MutexGuard<Buffer>>, BufferError> {
+        for buffer_mutex in &self.buffer_pool {
+            let buffer = buffer_mutex
+                .lock()
+                .map_err(|_| BufferError::MutexLockError)?;
+            if buffer.get_block().map_or(false, |b| *b == *block) {
+                return Ok(Some(buffer));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Chooses an unpinned buffer from the buffer pool.
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Option` containing a `MutexGuard` for a `Buffer` if an unpinned one is available.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the mutex lock is poisoned.
+    fn choose_unpinned_buffer(&self) -> Result<Option<MutexGuard<Buffer>>, BufferError> {
+        for buffer_mutex in &self.buffer_pool {
+            let buffer = buffer_mutex
+                .lock()
+                .map_err(|_| BufferError::MutexLockError)?;
+            if !buffer.is_pinned() {
+                return Ok(Some(buffer));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Checks if waiting for a buffer has exceeded the maximum time.
+    ///
+    /// # Arguments
+    ///
+    /// * `start_time`: The `Instant` at which the waiting started.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if waiting has exceeded the maximum time, otherwise `false`.
+    fn waiting_too_long(&self, start_time: Instant) -> bool {
+        start_time.elapsed() > Duration::from_millis(self.max_time)
+    }
+}

--- a/src/buffer/err.rs
+++ b/src/buffer/err.rs
@@ -1,0 +1,90 @@
+use crate::file::err::FileManagerError;
+use crate::log::err::LogError;
+use std::fmt;
+use std::sync::MutexGuard;
+use std::sync::PoisonError;
+
+/// Represents an exception when a buffer request cannot be fulfilled.
+/// This usually means the transaction needs to be aborted.
+#[derive(Debug, Clone)]
+pub struct BufferAbortException;
+
+impl std::fmt::Display for BufferAbortException {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Buffer request could not be satisfied, transaction needs to abort"
+        )
+    }
+}
+
+impl std::error::Error for BufferAbortException {}
+
+/// Enum for Buffer related errors.
+///
+/// It encapsulates errors from file management, logging, buffer operations,
+/// and mutex lock issues.
+#[derive(Debug)]
+pub enum BufferError {
+    /// An error related to the FileManager.
+    FileManagerError(FileManagerError),
+
+    /// An error related to the LogManager.
+    LogError(LogError),
+
+    /// An exception indicating a buffer request cannot be satisfied.
+    BufferAbortException(BufferAbortException),
+
+    /// An error when a mutex lock fails.
+    MutexLockError,
+}
+
+impl fmt::Display for BufferError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BufferError::FileManagerError(err) => write!(f, "FileManager error: {}", err),
+            BufferError::LogError(err) => write!(f, "Log error: {}", err),
+            BufferError::BufferAbortException(err) => write!(f, "Buffer abort exception: {}", err),
+            BufferError::MutexLockError => write!(f, "Mutex lock error"),
+        }
+    }
+}
+
+impl std::error::Error for BufferError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            BufferError::FileManagerError(err) => Some(err),
+            BufferError::LogError(err) => Some(err),
+            BufferError::BufferAbortException(err) => Some(err),
+            BufferError::MutexLockError => None,
+        }
+    }
+}
+
+/// Implement the conversion from FileManagerError to BufferError.
+impl From<FileManagerError> for BufferError {
+    fn from(error: FileManagerError) -> Self {
+        BufferError::FileManagerError(error)
+    }
+}
+
+/// Implement the conversion from LogError to BufferError.
+impl From<LogError> for BufferError {
+    fn from(error: LogError) -> Self {
+        BufferError::LogError(error)
+    }
+}
+
+/// Implement the conversion from BufferAbortException to BufferError.
+impl From<BufferAbortException> for BufferError {
+    fn from(error: BufferAbortException) -> Self {
+        BufferError::BufferAbortException(error)
+    }
+}
+
+/// Implement the conversion from a mutex poisoning error to BufferError.
+impl<T: 'static> From<PoisonError<MutexGuard<'_, T>>> for BufferError {
+    fn from(_error: PoisonError<MutexGuard<'_, T>>) -> Self {
+        BufferError::MutexLockError
+    }
+}

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1,0 +1,3 @@
+pub mod buffer;
+pub mod buffer_manager;
+pub mod err;

--- a/src/file/page.rs
+++ b/src/file/page.rs
@@ -167,7 +167,7 @@ impl Page {
         let mut bytes = vec![0; len];
         self.byte_buffer
             .read_exact(&mut bytes)
-            .map_err(PageError::IoError);
+            .map_err(PageError::IoError)?;
         Ok(bytes)
     }
 

--- a/src/log/log_iterator.rs
+++ b/src/log/log_iterator.rs
@@ -3,32 +3,37 @@ use crate::file::file_manager::FileManager;
 use crate::file::page::Page;
 use crate::log::err::LogError;
 use std::iter::Iterator;
+use std::sync::{Arc, Mutex};
 
-/// `LogIterator` is an iterator over the log records in a log file.
+/// `LogIterator` iterates over the log records in a log file.
 ///
-/// It allows for sequential reading of log records stored in blocks.
-/// The iterator starts from a given block and reads records until no more are available.
-pub struct LogIterator<'a> {
-    file_manager: &'a FileManager,
+/// This iterator allows for sequential reading of log records stored in blocks.
+/// The iterator starts from a given block and reads records until no more records are available.
+pub struct LogIterator {
+    file_manager: Arc<Mutex<FileManager>>,
     block: BlockId,
     page: Page,
     current_position: usize,
     boundary: usize,
 }
 
-impl<'a> LogIterator<'a> {
+impl LogIterator {
     /// Creates a new `LogIterator` starting from a given block.
     ///
     /// # Arguments
     ///
-    /// * `file_manager`: Reference to the `FileManager` for file operations.
-    /// * `block`: The `BlockId` where the iterator starts.
+    /// * `file_manager`: An `Arc<Mutex<FileManager>>` for performing file operations.
+    /// * `block`: The `BlockId` from which the iterator will start.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` wrapping the created `LogIterator` instance.
     ///
     /// # Errors
     ///
-    /// Returns a `LogError` if reading the block or page fails.
-    pub fn new(file_manager: &'a FileManager, block: BlockId) -> Result<Self, LogError> {
-        let mut page = Page::new_from_blocksize(file_manager.get_block_size());
+    /// Returns a `LogError` if there is an error in reading the block or the page.
+    pub fn new(file_manager: Arc<Mutex<FileManager>>, block: BlockId) -> Result<Self, LogError> {
+        let mut page = Page::new_from_blocksize(file_manager.lock().unwrap().get_block_size());
         let mut log_iterator = LogIterator {
             file_manager,
             block: block.clone(),
@@ -36,9 +41,7 @@ impl<'a> LogIterator<'a> {
             current_position: 0,
             boundary: 0,
         };
-        log_iterator
-            .move_to_block(block)
-            .map_err(|e| LogError::BlockError(e.to_string()))?;
+        log_iterator.move_to_block(block)?;
         Ok(log_iterator)
     }
 
@@ -48,7 +51,7 @@ impl<'a> LogIterator<'a> {
     ///
     /// Returns `true` if more records are available, otherwise `false`.
     pub fn has_next(&self) -> bool {
-        self.current_position < self.file_manager.get_block_size()
+        self.current_position < self.file_manager.lock().unwrap().get_block_size()
             || 0 < self.block.get_block_number()
     }
 
@@ -58,37 +61,46 @@ impl<'a> LogIterator<'a> {
     ///
     /// * `block`: The `BlockId` to move to.
     ///
+    /// # Returns
+    ///
+    /// Returns a `Result` that is `Ok(())` if the move was successful.
+    ///
     /// # Errors
     ///
-    /// Returns a `LogError` if reading the block or page fails.
+    /// Returns a `LogError` if there is an error in reading the block or the page.
     fn move_to_block(&mut self, block: BlockId) -> Result<(), LogError> {
+        // Acquire the lock and read the block, converting errors to LogError
         self.file_manager
+            .lock()
+            .map_err(|_| LogError::MutexLockError)?
             .read(&block, &mut self.page)
-            .map_err(|e| LogError::BlockError(e.to_string()))?;
+            .map_err(|e| LogError::FileManagerError(e.to_string()))?;
+
+        // Get the boundary, converting errors to LogError
         self.boundary = self
             .page
             .get_int(0)
             .map_err(|e| LogError::PageError(e.to_string()))? as usize;
+
         self.current_position = self.boundary;
         Ok(())
     }
 }
 
-impl<'a> Iterator for LogIterator<'a> {
+impl Iterator for LogIterator {
     type Item = Result<Vec<u8>, LogError>;
 
     /// Fetches the next log record.
     ///
     /// # Returns
     ///
-    /// Returns `Some(Ok(record))` if a record is successfully read,
-    /// `Some(Err(e))` if an error occurs, and `None` if no more records are available.
+    /// Returns an `Option` wrapping a `Result` that contains the log record or an error.
     fn next(&mut self) -> Option<Self::Item> {
         if !self.has_next() {
             return None;
         }
 
-        if self.current_position == self.file_manager.get_block_size() {
+        if self.current_position == self.file_manager.lock().unwrap().get_block_size() {
             self.block = BlockId::new(
                 self.block.get_file_name().to_string(),
                 self.block.get_block_number().saturating_sub(1),

--- a/src/log/log_manager.rs
+++ b/src/log/log_manager.rs
@@ -3,15 +3,14 @@ use crate::file::file_manager::FileManager;
 use crate::file::page::Page;
 use crate::log::err::LogError;
 use crate::log::log_iterator::LogIterator;
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 /// `LogManager` manages the writing and reading of log records.
 ///
 /// It keeps track of the current log block, the latest log sequence number (LSN),
 /// and the last saved LSN.
 pub struct LogManager {
-    file_manager: Arc<FileManager>,
+    file_manager: Arc<Mutex<FileManager>>,
     log_file: String,
     log_page: Page,
     current_block: BlockId,
@@ -21,33 +20,31 @@ pub struct LogManager {
 
 impl LogManager {
     /// Creates a new `LogManager`.
-    ///
-    /// # Arguments
-    ///
-    /// * `file_manager`: An `Arc` wrapped `FileManager` for file operations.
-    /// * `log_file`: The name of the log file.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `LogError` if initialization fails.
-    pub fn new(file_manager: Arc<FileManager>, log_file: String) -> Result<Self, LogError> {
-        let mut log_page = Page::new_from_blocksize(file_manager.get_block_size());
-        let logsize = file_manager
-            .length(&log_file)
-            .map_err(|e| LogError::FileManagerError(e.to_string()))?;
+    pub fn new(file_manager: Arc<Mutex<FileManager>>, log_file: String) -> Result<Self, LogError> {
+        let mut log_page = {
+            let fm = file_manager.lock().unwrap();
+            Page::new_from_blocksize(fm.get_block_size())
+        };
+
+        let logsize = {
+            let fm = file_manager.lock().unwrap();
+            fm.length(&log_file)
+                .map_err(|e| LogError::FileManagerError(e.to_string()))?
+        };
 
         let current_block = if logsize == 0 {
-            Self::append_new_block(&file_manager, &log_file, &mut log_page)
+            let fm = file_manager.lock().unwrap();
+            Self::append_new_block(&fm, &log_file, &mut log_page)
                 .map_err(|e| LogError::FileManagerError(e.to_string()))?
         } else {
+            let fm = file_manager.lock().unwrap();
             let block = BlockId::new(log_file.clone(), logsize - 1);
-            file_manager
-                .read(&block, &mut log_page)
+            fm.read(&block, &mut log_page)
                 .map_err(|e| LogError::FileManagerError(e.to_string()))?;
             block
         };
 
-        Ok(LogManager {
+        Ok(Self {
             file_manager,
             log_file,
             log_page,
@@ -58,14 +55,6 @@ impl LogManager {
     }
 
     /// Flushes log records up to a given LSN.
-    ///
-    /// # Arguments
-    ///
-    /// * `lsn`: The log sequence number up to which records should be flushed.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `LogError` if flushing fails.
     pub fn flush_by_lsn(&mut self, lsn: i32) -> Result<(), LogError> {
         let last_saved_lsn = *self
             .last_saved_lsn
@@ -78,31 +67,15 @@ impl LogManager {
     }
 
     /// Returns a `LogIterator` for reading log records.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `LogError` if iterator creation fails.
     pub fn iterator(&mut self) -> Result<LogIterator, LogError> {
         self.flush()?;
         Ok(LogIterator::new(
-            &self.file_manager,
+            self.file_manager.clone(),
             self.current_block.clone(),
         )?)
     }
 
     /// Appends a log record to the log file.
-    ///
-    /// # Arguments
-    ///
-    /// * `log_record`: The log record to append.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `LogError` if appending fails.
-    ///
-    /// # Returns
-    ///
-    /// Returns the LSN of the appended log record.
     pub fn append(&mut self, log_record: &[u8]) -> Result<i32, LogError> {
         let mut boundary = self
             .log_page
@@ -113,8 +86,11 @@ impl LogManager {
 
         if boundary.checked_sub(bytes_needed).unwrap_or(0) < std::mem::size_of::<i32>() {
             self.flush()?;
-            self.current_block =
-                Self::append_new_block(&self.file_manager, &self.log_file, &mut self.log_page)?;
+            self.current_block = Self::append_new_block(
+                &self.file_manager.lock().unwrap(),
+                &self.log_file,
+                &mut self.log_page,
+            )?;
             boundary = self
                 .log_page
                 .get_int(0)
@@ -125,7 +101,6 @@ impl LogManager {
         self.log_page
             .set_bytes(record_position, log_record)
             .map_err(|e| LogError::PageError(e.to_string()))?;
-
         self.log_page
             .set_int(0, record_position as i32)
             .map_err(|e| LogError::PageError(e.to_string()))?;
@@ -138,20 +113,6 @@ impl LogManager {
     }
 
     /// Appends a new block to the log file.
-    ///
-    /// # Arguments
-    ///
-    /// * `file_manager`: Reference to the `FileManager` for file operations.
-    /// * `log_file`: The name of the log file.
-    /// * `log_page`: The log page to write.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `LogError` if appending a new block fails.
-    ///
-    /// # Returns
-    ///
-    /// Returns the `BlockId` of the new block.
     fn append_new_block(
         file_manager: &FileManager,
         log_file: &String,
@@ -170,12 +131,10 @@ impl LogManager {
     }
 
     /// Flushes the current log page to disk.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `LogError` if flushing fails.
     fn flush(&mut self) -> Result<(), LogError> {
         self.file_manager
+            .lock()
+            .unwrap()
             .write(&self.current_block, &mut self.log_page)
             .map_err(|e| LogError::FileManagerError(e.to_string()))?;
         let mut last_saved_lsn = self

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod buffer;
 mod file;
 mod log;
 mod server;

--- a/src/server/oxide_db.rs
+++ b/src/server/oxide_db.rs
@@ -1,33 +1,57 @@
+use crate::buffer::buffer_manager::BufferManager;
 use crate::file::file_manager::FileManager;
 use crate::log::log_manager::LogManager;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 const LOG_FILE: &str = "oxidedb.log";
 
 pub struct OxideDB {
     block_size: usize,
-    file_manager: Arc<FileManager>,
-    log_manager: LogManager,
+    file_manager: Arc<Mutex<FileManager>>,
+    log_manager: Arc<Mutex<LogManager>>,
+    buffer_manager: BufferManager,
 }
 
 impl OxideDB {
-    pub fn new_for_debug(db_directory: PathBuf, block_size: usize) -> OxideDB {
-        let file_manager = Arc::new(FileManager::new(db_directory, block_size).unwrap());
-        let log_manager = LogManager::new(Arc::clone(&file_manager), LOG_FILE.to_string()).unwrap();
+    pub fn new_for_debug(db_directory: PathBuf, block_size: usize, buffer_size: usize) -> OxideDB {
+        let file_manager = Arc::new(Mutex::new(
+            FileManager::new(db_directory, block_size).unwrap(),
+        ));
+
+        let block_size_fetched = {
+            let fm = file_manager.lock().unwrap();
+            fm.get_block_size()
+        };
+
+        let log_manager = Arc::new(Mutex::new(
+            LogManager::new(Arc::clone(&file_manager), LOG_FILE.to_string()).unwrap(),
+        ));
+
+        let buffer_manager = BufferManager::new(
+            Arc::clone(&file_manager),
+            Arc::clone(&log_manager),
+            buffer_size,
+        )
+        .unwrap();
 
         OxideDB {
-            block_size: file_manager.get_block_size(),
+            block_size: block_size_fetched,
             file_manager,
             log_manager,
+            buffer_manager,
         }
     }
 
-    pub fn get_file_manager(&self) -> &FileManager {
+    pub fn get_file_manager(&self) -> &Arc<Mutex<FileManager>> {
         &self.file_manager
     }
 
-    pub fn get_log_manager(&mut self) -> &mut LogManager {
-        &mut self.log_manager
+    pub fn get_log_manager(&self) -> &Arc<Mutex<LogManager>> {
+        &self.log_manager
+    }
+
+    pub fn get_buffer_manager(&self) -> &BufferManager {
+        &self.buffer_manager
     }
 }

--- a/src/tests/buffer_file_test.rs
+++ b/src/tests/buffer_file_test.rs
@@ -1,0 +1,69 @@
+use crate::file::block_id::BlockId;
+use crate::file::page::Page;
+use crate::server::oxide_db::OxideDB;
+use std::fs::remove_dir_all;
+use std::path::PathBuf;
+
+/// Tests buffer management operations in `BufferManager`.
+///
+/// This test does the following:
+/// - Pins a block and writes a string and an integer to specific positions within the block.
+/// - Marks the block as modified and unpins it.
+/// - Pins the same block again and reads back the data to verify that it matches the written values.
+#[test]
+fn buffer_file_test() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a test directory for OxideDB with a block size of 400 and only 3 buffers.
+    let test_directory = PathBuf::from("bufferfiletest");
+    let db = OxideDB::new_for_debug(test_directory.clone(), 400, 8);
+    let buffer_manager = db.get_buffer_manager();
+
+    // Pin the block with id ("testfile", 2) to write data
+    let block_id = BlockId::new("testfile".to_string(), 2);
+    let mut buffer1 = buffer_manager.pin(block_id.clone())?;
+    let page1 = buffer1.get_contents();
+    let position1: usize = 88; // Starting position for writing data
+
+    // Write a string and an integer to the pinned block
+    page1.set_string(position1, "abcdefghijklm")?;
+    let size = Page::max_length("abcdefghijklm".len());
+    let position2 = position1 + size;
+    page1.set_int(position2, 345)?;
+
+    // Mark the block as modified
+    buffer1.set_modified(1, 0);
+
+    // Unpin the block after modification
+    buffer_manager.unpin(buffer1)?;
+
+    // Pin the same block again to read the data
+    let mut buffer2 = buffer_manager.pin(block_id.clone())?;
+    let page2 = buffer2.get_contents();
+
+    // Read and verify the set values
+    let read_int = page2.get_int(position2)?;
+    let read_str = page2.get_string(position1)?;
+
+    // Verify that the read integer is as expected
+    assert_eq!(
+        read_int, 345,
+        "Integer value mismatch at position {}",
+        position2
+    );
+
+    // Verify that the read string is as expected
+    assert_eq!(
+        read_str, "abcdefghijklm",
+        "String value mismatch at position {}",
+        position1
+    );
+
+    println!("offset {} contains {}", position2, read_int);
+    println!("offset {} contains {}", position1, read_str);
+
+    // Unpin the block after reading
+    buffer_manager.unpin(buffer2)?;
+
+    // Clean up the test environment
+    remove_dir_all(test_directory)?;
+    Ok(())
+}

--- a/src/tests/buffer_manager_test.rs
+++ b/src/tests/buffer_manager_test.rs
@@ -1,0 +1,99 @@
+use crate::file::block_id::BlockId;
+use crate::server::oxide_db::OxideDB;
+use std::fs::remove_dir_all;
+use std::path::PathBuf;
+
+/// Tests the behavior of the `BufferManager` under different scenarios.
+///
+/// This test performs the following actions:
+/// - Pins the first three blocks and stores their IDs for later use.
+/// - Unpins one of the pinned blocks to make space in the buffer.
+/// - Pins two more blocks (including repinning one that was unpinned) and stores their IDs.
+/// - Checks and displays the number of available buffers.
+/// - Attempts to pin a block when no buffers are expected to be available, validating that an exception is raised.
+/// - Frees up a buffer by unpinning a block and validates that pinning a new block is now possible.
+/// - Outputs the final state of which blocks are pinned to which buffers.
+#[test]
+fn buffer_manager_test() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a test directory for OxideDB with a block size of 400 and only 3 buffers.
+    let test_directory = PathBuf::from("buffermgrtest");
+    let db = OxideDB::new_for_debug(test_directory.clone(), 400, 3);
+    let buffer_manager = db.get_buffer_manager();
+
+    let mut blocks: [Option<BlockId>; 6] = Default::default();
+
+    // Pin the first three blocks and store their IDs in an array.
+    for i in 0usize..3 {
+        let buffer = buffer_manager.pin(BlockId::new("testfile".to_string(), i as u32))?;
+        let block = buffer.get_block().ok_or("Failed to get block")?;
+        blocks[i] = Some(block.clone());
+    }
+
+    // Unpin one of the pinned blocks.
+    if let Some(buffer) = buffer_manager
+        .find_existing_buffer(&blocks[1].as_ref().ok_or("Block should exist")?.clone())?
+    {
+        buffer_manager.unpin(buffer)?;
+    }
+
+    // Pin two more blocks
+    {
+        // Block 0 pinned twice
+        let buffer = buffer_manager.pin(BlockId::new("testfile".to_string(), 0))?;
+        let block = buffer.get_block().ok_or("Failed to get block")?;
+        blocks[3] = Some(block.clone());
+    }
+    {
+        // Block 1 repinned
+        let buffer = buffer_manager.pin(BlockId::new("testfile".to_string(), 1))?;
+        let block = buffer.get_block().ok_or("Failed to get block")?;
+        blocks[4] = Some(block.clone());
+    }
+
+    // Check and display the number of available buffers.
+    {
+        let available_buffers = buffer_manager.get_number_available()?;
+        println!("Available buffers: {}", *available_buffers);
+    }
+
+    // Attempt to pin a block when no buffers are expected to be available.
+    println!("Attempting to pin block 3...");
+    {
+        match buffer_manager.pin(BlockId::new("testfile".to_string(), 3)) {
+            Ok(buffer) => {
+                let block = buffer.get_block().ok_or("Failed to get block")?;
+                blocks[5] = Some(block.clone())
+            }
+            Err(_) => println!("Exception: No available buffers\n"),
+        }
+    }
+
+    // Unpin another block to free up a buffer.
+    if let Some(buffer) = buffer_manager
+        .find_existing_buffer(&blocks[2].as_ref().ok_or("Block should exist")?.clone())?
+    {
+        buffer_manager.unpin(buffer)?;
+    }
+
+    // Try to pin the block again (this should now work due to the freed buffer).
+    let buffer = buffer_manager.pin(BlockId::new("testfile".to_string(), 3))?;
+    let block = buffer.get_block().ok_or("Failed to get block")?;
+    blocks[5] = Some(block.clone());
+
+    // Output the final allocation of blocks to buffers.
+    println!("Final Buffer Allocation:");
+    for (i, block) in blocks.iter().enumerate() {
+        if let Some(b) = block {
+            println!(
+                "buffer{} pinned to block [file {}, block {}]",
+                i,
+                b.get_file_name(),
+                b.get_block_number()
+            );
+        }
+    }
+
+    // Cleanup the test directory.
+    remove_dir_all(test_directory)?;
+    Ok(())
+}

--- a/src/tests/buffer_test.rs
+++ b/src/tests/buffer_test.rs
@@ -1,0 +1,81 @@
+use crate::file::block_id::BlockId;
+use crate::file::page::Page;
+use crate::server::oxide_db::OxideDB;
+use std::fs::remove_dir_all;
+use std::path::PathBuf;
+
+/// Tests various operations on a `Buffer`, including pinning, modifying, and flushing.
+///
+/// This test performs the following actions:
+/// - Pins a block ("testfile", 1) and retrieves its content.
+/// - Reads an integer at a specific offset (80), modifies it, and marks the buffer as modified.
+/// - Unpins the modified buffer.
+/// - Pins additional blocks, triggering a flush operation for the modified buffer.
+/// - Re-pins the flushed block to verify if the modifications are preserved.
+/// - Further modifies the block and marks it as modified.
+/// - Reads the block directly from disk to confirm that the original modification was flushed correctly.
+#[test]
+fn buffer_test() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a test directory for OxideDB with a block size of 400 and only 3 buffers.
+    let test_direcotry = PathBuf::from("buffertest");
+    let db = OxideDB::new_for_debug(test_direcotry.clone(), 400, 3);
+    let buffer_manager = db.get_buffer_manager();
+
+    // Pin a block with id ("testfile", 1)
+    let mut buffer1 = buffer_manager.pin(BlockId::new("testfile".to_string(), 1))?;
+    let page1 = buffer1.get_contents();
+
+    // Read, modify and write back an integer value at offset 80
+    let number1 = page1.get_int(80)?;
+    page1.set_int(80, number1 + 1)?;
+    buffer1.set_modified(1, 0);
+    println!("The new value is {}", number1 + 1);
+
+    // Unpin the modified block
+    buffer_manager.unpin(buffer1)?;
+
+    // Pin additional blocks. One of these will trigger a flush for buffer1.
+    let block2 = {
+        let buffer2 = buffer_manager.pin(BlockId::new("testfile".to_string(), 2))?;
+        buffer2.get_block().ok_or("Failed to get block")?.clone()
+    };
+    {
+        let _buffer3 = buffer_manager.pin(BlockId::new("testfile".to_string(), 3))?;
+    }
+    {
+        let _buffer4 = buffer_manager.pin(BlockId::new("testfile".to_string(), 4))?;
+    }
+
+    // Re-read the flushed block to check if the modification is preserved
+    if let Some(mut buffer2) = buffer_manager.find_existing_buffer(&block2)? {
+        buffer_manager.unpin(buffer2)?;
+        buffer2 = buffer_manager.pin(BlockId::new("testfile".to_string(), 1))?;
+        let page2 = buffer2.get_contents();
+        let old_value = page2.get_int(80)?;
+        println!("Old value before set: {}", old_value);
+
+        // Modify the block again
+        page2.set_int(80, 9999)?;
+        let new_value = page2
+            .get_int(80)
+            .map_err(|_| "Failed to get integer at offset 80")?;
+        buffer2.set_modified(1, 0);
+        println!("New value after set: {}", new_value);
+
+        // Read the block directly from disk to confirm that the original modification was flushed
+        let file_manager = db
+            .get_file_manager()
+            .lock()
+            .map_err(|_| "Failed to lock file manager")?;
+        let mut page_to_check = Page::new_from_blocksize(400);
+        let block_to_check = BlockId::new("testfile".to_string(), 1);
+        file_manager.read(&block_to_check, &mut page_to_check)?;
+        let flushed_value = page_to_check.get_int(80)?;
+
+        assert_eq!(flushed_value, number1 + 1); // Assertion to verify flushed value
+    }
+
+    // Cleanup the test directory
+    remove_dir_all(test_direcotry)?;
+    Ok(())
+}

--- a/src/tests/file_test.rs
+++ b/src/tests/file_test.rs
@@ -1,7 +1,7 @@
 use crate::file::block_id::BlockId;
-use crate::file::file_manager::FileManager;
 use crate::file::page::Page;
 use crate::server::oxide_db::OxideDB;
+use std::fs::remove_dir_all;
 use std::path::PathBuf;
 
 /// Tests file read and write operations in `FileManager`.
@@ -14,11 +14,10 @@ use std::path::PathBuf;
 /// - Checks if the read values match the written values.
 #[test]
 fn file_test() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize a new OxideDB instance for debugging
-    let db = OxideDB::new_for_debug(PathBuf::from("filetest"), 400);
-
-    // Acquire a FileManager to perform file operations
-    let file_manager = db.get_file_manager();
+    // Create a test directory for OxideDB with a block size of 400 and only 3 buffers.
+    let test_directory = PathBuf::from("filetest");
+    let db = OxideDB::new_for_debug(test_directory.clone(), 400, 8);
+    let file_manager = db.get_file_manager().lock().unwrap();
 
     // Create a block ID for testing
     let block = BlockId::new("testfile".to_string(), 2);
@@ -50,5 +49,7 @@ fn file_test() -> Result<(), Box<dyn std::error::Error>> {
     // Assert that the read string matches the written string
     assert_eq!(page2.get_string(position1)?, "abcdefghijklm");
 
+    // Cleanup the test directory.
+    remove_dir_all(test_directory)?;
     Ok(())
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,2 +1,5 @@
+pub mod buffer_file_test;
+pub mod buffer_manager_test;
+pub mod buffer_test;
 pub mod file_test;
 pub mod log_test;


### PR DESCRIPTION
- Implement BufferManager struct with core functionalities
  - Add methods for pinning, unpinning, and flushing buffers
  - Implement a find_existing_buffer method for cache lookup
  - Add get_number_available method for buffer pool statistics

- Add Mutex for thread-safe buffer pool management
  - Implement a mutex-protected HashMap for buffer-to-block mapping
  - Use Mutex<i32> for managing the available buffer count

- Add unit tests
  - Implement buffer_file_test for testing BufferManager in file operations
  - Implement buffer_manager_test for testing different scenarios in buffer management
  - Implement buffer_test for general Buffer operations including flushing

- Document the code
  - Add Rustdoc comments for BufferManager and Buffer
  - Provide explanations for arguments and errors in the documentation